### PR TITLE
Add schema.org Course JSON-LD markup for enhanced discoverability

### DIFF
--- a/resources/overrides/main.html
+++ b/resources/overrides/main.html
@@ -8,4 +8,32 @@
   {% if page.meta and page.meta.tags %}
     <meta name="tags" content="{{ page.meta.tags }}"/>
   {% endif %}
+
+  <!-- Schema.org JSON-LD for Course -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org/",
+    "@type": "Course",
+    "name": "Data Steward Training Curriculum",
+    "description": "This curriculum for entry-level data stewards has been developed by a working group in the Skills4EOSC project (Task 4.1 of the project), and is intended to provide guidance to teach the foundational topics required for data stewardship.
+    In this guide, we explain briefly what we intend with the different components of the curriculum, and how an instructor can use them.",
+    "url": "{{ page.url | absolute_url }}",
+    "provider": {
+      "@type": "Organization",
+      "name": "Skills4EOSC",
+      "url": "https://skills4eosc.eu"
+    },
+    "keywords": [
+      "Data Stewardship",
+      "FAIR Data",
+      "Training Curriculum",
+      "Data Steward",
+      "Entry-level"
+    ],
+    "learningResourceType": "Curriculum",
+    "educationalLevel": "Professional",
+    "datePublished": "2023-06-23"
+  }
+  </script>
+  <!-- end JSON-LD -->
 {% endblock %}

--- a/resources/overrides/main.html
+++ b/resources/overrides/main.html
@@ -17,7 +17,7 @@
     "name": "Data Steward Training Curriculum",
     "description": "This curriculum for entry-level data stewards has been developed by a working group in the Skills4EOSC project (Task 4.1 of the project), and is intended to provide guidance to teach the foundational topics required for data stewardship.
     In this guide, we explain briefly what we intend with the different components of the curriculum, and how an instructor can use them.",
-    "url": "{{ page.url | absolute_url }}",
+    "url": "https://skills4eosc-dscurriculum.github.io/DataSteward-Training-Curriculum/latest/",
     "provider": {
       "@type": "Organization",
       "name": "Skills4EOSC",
@@ -31,8 +31,8 @@
       "Entry-level"
     ],
     "learningResourceType": "Curriculum",
-    "educationalLevel": "Professional",
-    "datePublished": "2023-06-23"
+    "educationalLevel": "beginner",
+    "datePublished": "2025-06-23"
   }
   </script>
   <!-- end JSON-LD -->


### PR DESCRIPTION

**Description**
This PR embeds structured Course metadata into the `<head>` of the generated pages via the `site_meta` block in `resources/overrides/main.html`. By adding a `<script type="application/ld+json">` snippet that conforms to the [[schema.org Course specification](https://schema.org/Course)](https://schema.org/Course), search engines and specialist harvesters will be able to recognise and index the Data Steward Training Curriculum as a formal learning resource.

**Changes**

* **resources/overrides/main.html**:

  * Extend the existing `site_meta` block to include a dynamic JSON-LD snippet with fields for `@type: Course`, `name`, `description`, `url` (using `{{ page.url | absolute_url }}`), `provider`, `keywords`, `learningResourceType`, `educationalLevel`, and `datePublished`.

**Verification**

1. Built and served the site locally; confirmed the `<script>` appears in the `<head>` of `/latest/`.

- In your browser, right-click and choose “View Page Source” (or hit Ctrl+U/Cmd+U).

- Search (Ctrl+F/Cmd+F) for <script type="application/ld+json">.

- You should see your JSON-LD block at the bottom of the <head> section.

2. Run the output through Google’s Rich Results Test—no errors in the Course markup.

**Why**
Embedding this metadata will:

* Improve your SEO  (Search Engine Optimization) by signalling to crawlers that this is a Course resource.
* Enable rich search result features (e.g., “Course” badges) where supported.
* Increase interoperability with third-party aggregators (e.g., academic catalogs, training portals).

Please review and merge if OK!